### PR TITLE
Use RedshiftClient to execute transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # ReplaceRedshiftDataLambda
 
-This repository contains the code used by the [ReplaceRedshiftData-qa](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ReplaceRedshiftData-qa?newFunction=true&tab=code) and [ReplaceRedshiftData-production](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ReplaceRedshiftData-production?newFunction=true&tab=code) AWS lambda functions. It copies data into a table while ensuring some key remains unique. For now, that key is hardcoded to be the patron_id, but it would be easy to generalize if necessary. Given a staging table and a main table, this function does the following:
-1) Deletes all rows in the main table that match rows in the staging table for a specified column
-2) Copies over all the rows from the staging table into the main table
-3) Deletes all rows in the staging table
+This repository contains the code used by the [ReplaceRedshiftData-qa](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ReplaceRedshiftData-qa?newFunction=true&tab=code) and [ReplaceRedshiftData-production](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ReplaceRedshiftData-production?newFunction=true&tab=code) AWS lambda functions. It copies data into a table while ensuring some key remains unique. For now, that key is hardcoded to be the `patron_id`, but it would be easy to generalize if necessary. Given a staging table and a main table, this function does the following:
+1) Checks that all rows in the staging table have a unique value for the specified column. If not and all the duplicate rows are the same, deletes all but one of these rows from the staging table. If the duplicate rows are different, throws an error. 
+2) Deletes all rows in the main table that match rows in the staging table for a specified column
+3) Copies over all the rows from the staging table into the main table
+4) Deletes all rows in the staging table
 
 ## Git workflow
 This repo uses the [Main-QA-Production](https://github.com/NYPL/engineering-general/blob/main/standards/git-workflow.md#main-qa-production) git workflow.

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -30,7 +30,6 @@ _DUPLICATES_QUERY = '''
 
 def lambda_handler(event, context):
     logger.info('Starting lambda processing')
-
     kms_client = KmsClient()
     redshift_client = RedshiftClient(
         kms_client.decrypt(os.environ['REDSHIFT_DB_HOST']),

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,81 +1,94 @@
 import json
 import os
-import redshift_connector
 
-from botocore.exceptions import ClientError
 from nypl_py_utils.classes.kms_client import KmsClient
+from nypl_py_utils.classes.redshift_client import RedshiftClient
 from nypl_py_utils.functions.log_helper import create_log
 
 logger = create_log('lambda_function')
 
+_MAIN_DELETION_QUERY = '''
+    DELETE FROM {main_table}
+    USING {staging_table}
+    WHERE {main_table}.patron_id = {staging_table}.patron_id;'''
+
+_DUPLICATE_DELETION_QUERY = '''
+    DELETE FROM {staging_table}
+    WHERE patron_id IN ({duplicate_ids});'''
+
+_DUPLICATES_QUERY = '''
+    SELECT *
+    FROM {staging_table} JOIN
+    (
+        SELECT patron_id, COUNT(patron_id) AS patron_count
+        FROM {staging_table}
+        GROUP BY patron_id
+    ) t
+    ON t.patron_id = {staging_table}.patron_id
+    WHERE patron_count > 1;'''
+
 
 def lambda_handler(event, context):
-    logger.info('Connecting to Redshift')
+    logger.info('Starting lambda processing')
+
     kms_client = KmsClient()
-    try:
-        connection = redshift_connector.connect(
-            host=kms_client.decrypt(os.environ['REDSHIFT_DB_HOST']),
-            database=os.environ['REDSHIFT_DB_NAME'],
-            user=kms_client.decrypt(os.environ['REDSHIFT_DB_USER']),
-            password=kms_client.decrypt(os.environ['REDSHIFT_DB_PASSWORD']))
-        kms_client.close()
-    except ClientError as e:
-        connection = None
-        kms_client.close()
-        logger.error('Error connecting to database: {}'.format(e))
-        raise ReplaceRedshiftDataError(
-            'Error connecting to database: {}'.format(e)) from None
+    redshift_client = RedshiftClient(
+        kms_client.decrypt(os.environ['REDSHIFT_DB_HOST']),
+        os.environ['REDSHIFT_DB_NAME'],
+        kms_client.decrypt(os.environ['REDSHIFT_DB_USER']),
+        kms_client.decrypt(os.environ['REDSHIFT_DB_PASSWORD']))
+    kms_client.close()
+    redshift_client.connect()
 
-    logger.info('Starting transaction')
-    try:
-        cursor = connection.cursor()
-        cursor.execute('SELECT COUNT(*) FROM {staging_table};'.format(
-            staging_table=os.environ['STAGING_TABLE']))
-        total_length = cursor.fetchall()[0][0]
-        cursor.execute(
-            'SELECT COUNT(DISTINCT patron_id) FROM {staging_table};'.format(
-                staging_table=os.environ['STAGING_TABLE']))
-        distinct_length = cursor.fetchall()[0][0]
-        if total_length != distinct_length:
-            logger.error('Number of distinct patrons does not equal total '
-                         'number of rows')
+    logger.info('Checking for duplicate records')
+    raw_duplicates = redshift_client.execute_query(_DUPLICATES_QUERY.format(
+        staging_table=os.environ['STAGING_TABLE']))
+    unique_map = {}
+    for row in raw_duplicates:
+        id = row[0]
+        if id not in unique_map:
+            unique_map[id] = row
+        elif unique_map[id] != row:
+            logger.error('Duplicate patron ids with different values found')
             raise ReplaceRedshiftDataError(
-                'Number of distinct patrons does not equal total number of '
-                'rows') from None
+                'Duplicate patron ids with different values found')
+    # If there are duplicate rows, delete all of them and insert each row back
+    # individually into the staging table
+    if len(unique_map.keys()) > 0:
+        duplicate_ids = "'" + "','".join(unique_map.keys()) + "'"
+        queries = [(_DUPLICATE_DELETION_QUERY.format(
+            staging_table=os.environ['STAGING_TABLE'],
+            duplicate_ids=duplicate_ids), None)]
 
-        cursor.execute('BEGIN TRANSACTION;')
-        cursor.execute((
-            'DELETE FROM {main_table} '
-            'USING {staging_table} '
-            'WHERE {main_table}.patron_id = {staging_table}.patron_id;'
-        ).format(main_table=os.environ['MAIN_TABLE'],
-                 staging_table=os.environ['STAGING_TABLE']))
-        cursor.execute(
-            'INSERT INTO {main_table} SELECT * FROM {staging_table};'.format(
-                main_table=os.environ['MAIN_TABLE'],
-                staging_table=os.environ['STAGING_TABLE']
-            ))
-        cursor.execute('DELETE FROM {staging_table};'.format(
-            staging_table=os.environ['STAGING_TABLE']))
-        cursor.execute('END TRANSACTION;')
-        connection.commit()
+        # Need to include %s for each value that's being inserted. This is
+        # len(row)-2 because the row contains two extra fields from the join.
+        placeholder_length = len(next(iter(unique_map.values()))) - 2
+        placeholder = ", ".join(["%s"] * placeholder_length)
+        insert_query = 'INSERT INTO {staging_table} VALUES ({placeholder});'\
+            .format(staging_table=os.environ['STAGING_TABLE'],
+                    placeholder=placeholder)
+        for value in unique_map.values():
+            queries.append((insert_query, value[:-2]))
+        redshift_client.execute_transaction(queries)
 
-        logger.info('Finished transaction')
-        return {
-            "statusCode": 200,
-            "body": json.dumps({
-                "message": "Job ran successfully."
-            }),
-        }
-    except Exception as e:
-        connection.rollback()
-        logger.error('Error executing transaction: {}'.format(e))
-        raise ReplaceRedshiftDataError(
-            'Error executing queries: {}'.format(e)) from None
-    finally:
-        logger.info('Closing connections')
-        cursor.close()
-        connection.close()
+    redshift_client.execute_transaction([
+        (_MAIN_DELETION_QUERY.format(
+            main_table=os.environ['MAIN_TABLE'],
+            staging_table=os.environ['STAGING_TABLE']), None),
+        ('INSERT INTO {main_table} SELECT * FROM {staging_table};'.format(
+            main_table=os.environ['MAIN_TABLE'],
+            staging_table=os.environ['STAGING_TABLE']), None),
+        ('DELETE FROM {staging_table};'.format(
+            staging_table=os.environ['STAGING_TABLE']), None)])
+    redshift_client.close_connection()
+
+    logger.info('Finished lambda processing')
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "Job ran successfully."
+        }),
+    }
 
 
 class ReplaceRedshiftDataError(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils==1.0.0
+nypl-py-utils==1.0.1
 redshift_connector


### PR DESCRIPTION
Also updated duplicate behavior -- do not throw an error unless the duplicate patron id rows are different. If they are the same, only copy over one of the rows to the main table.